### PR TITLE
Refactoring Rename and Move Methods

### DIFF
--- a/src/MyFrame.java
+++ b/src/MyFrame.java
@@ -2,7 +2,6 @@ import java.awt.Color;
 import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.HashMap;
 
 import javax.swing.BorderFactory;
 import javax.swing.JFrame;
@@ -12,23 +11,22 @@ import javax.swing.ImageIcon;
 
 @SuppressWarnings("serial")
 public class MyFrame extends JFrame implements ActionListener {
-	
+
 	JButton button;
 	JLabel label;
 	JButton continueButton = new JButton("Continue");
-	
-	
-	HashMap<String,String> logininfo = new HashMap<String,String>();	
-	MyFrame(){
-	
-	label = new JLabel();
-	label.setBounds(300,0,175,150);
-	label.setVisible(true);
-	
+
+	MyFrame() {
+
+		label = new JLabel();
+		label.setBounds(300, 0, 175, 150);
+		label.setVisible(true);
+
 	}
+
 	@Override
 	public void actionPerformed(ActionEvent e) {
 		// TODO Auto-generated method stub
-		
+
 	}
 }


### PR DESCRIPTION
Rename Method was in Login page class. Login Button method was renamed to LoginCheck to avoid duplication. Refactoring Move method was a Hashmap string that did not belong to the MyFram class and was moved to the IDsandPasswords Class.